### PR TITLE
Create emitter at the root of the module

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,13 @@
 var raf = require('component-raf');
 var scrollTop = require('scrolltop');
 var Emitter = require('tiny-emitter');
-var emitter;
+var emitter = new Emitter();
 var rafId = -1;
 var scrollY = 0;
 var deltaY = 0;
 var ticking = false;
 
 module.exports = {
-  init: function() {
-      if(!emitter) emitter = new Emitter();
-      return this;
-  },
-
   add: function(fn) {
     emitter.on('scroll', fn);
 
@@ -49,7 +44,6 @@ module.exports = {
   destroy: function() {
     raf.cancel(rafId);
     emitter.off();
-    emitter = null;
     scrollY = 0;
     deltaY = 0;
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "tiny-emitter": "^1.0.0"
   },
   "devDependencies": {
+    "beefy": "2.1.5",
+    "browserify": "11.0.1",
+    "phantomjs": "1.9.18",
     "tape": "^3.5.0"
   }
 }


### PR DESCRIPTION
Tja,

Since `init` only checks if `emitter` is defined, we can instead
create it at the root of the module. Therefore it will be created the
first time the module is imported.
Like that we don't need to call the `init` function at the root of
our project.

Let me know if I missed something 