### PR TITLE
Fix .remove() and .destroy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,7 @@ module.exports = {
 
   destroy: function() {
     raf.cancel(rafId);
-    if (emitter) {
-        emitter.off();
-        emitter = null;
-    }
+    emitter = new Emitter();
     scrollY = 0;
     deltaY = 0;
   }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
     emitter.off('scroll', fn);
 
     // Stop raf if there is no more callbacks
-    if (emitter && emitter.e.scroll && emitter.e.scroll.length < 1) {
+    if (!emitter.e.scroll || emitter.e.scroll.length < 1) {
       raf.cancel(rafId);
     }
   },

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = {
 };
 
 function getEvent() {
-  if(ticking) {
+  if (ticking) {
     var scroll = scrollTop();
     deltaY = scroll - scrollY;
   }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/prova -b ./test/**/*.js -l phantom -q",
-    "test-browser": "./node_modules/.bin/prova -b ./test/**/*.js -l chrome"
+    "test": "prova -b ./test/**/*.js -l phantom -q",
+    "test-browser": "prova -b ./test/**/*.js -l chrome"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -28,3 +28,13 @@ test('Manual call', function(assert) {
     assert.end();
   });
 });
+
+test('.destroy()', function(assert) {
+  rafScroll.add(function() {});
+  rafScroll.destroy();
+  rafScroll.add(function(e) {
+    rafScroll.destroy();
+    assert.equal(e !== undefined, true, 'the callback should have been called');
+    assert.end();
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,6 @@ var raf = require('component-raf');
 document.body.style.height = window.innerHeight + 500 + 'px';
 
 test('rAF call', function(assert) {
-    rafScroll.init();
     rafScroll.addOnce(function(event) {
         assert.notDeepEqual(event.deltaY, 0, 'Event shouldn\'t be called if scroll hasn\'t changed.');
         assert.deepEqual(event.deltaY, 50, 'deltaY should reflect the latest change.');
@@ -20,7 +19,6 @@ test('rAF call', function(assert) {
 });
 
 test('Manual call', function(assert) {
-    rafScroll.init();
     window.scrollTo(0, 50);
 
     raf(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -8,23 +8,23 @@ var raf = require('component-raf');
 document.body.style.height = window.innerHeight + 500 + 'px';
 
 test('rAF call', function(assert) {
-    rafScroll.addOnce(function(event) {
-        assert.notDeepEqual(event.deltaY, 0, 'Event shouldn\'t be called if scroll hasn\'t changed.');
-        assert.deepEqual(event.deltaY, 50, 'deltaY should reflect the latest change.');
-        rafScroll.destroy();
-        assert.end();
-    });
+  rafScroll.addOnce(function(event) {
+    assert.notDeepEqual(event.deltaY, 0, 'Event shouldn\'t be called if scroll hasn\'t changed.');
+    assert.deepEqual(event.deltaY, 50, 'deltaY should reflect the latest change.');
+    rafScroll.destroy();
+    assert.end();
+  });
 
-    window.scrollTo(0, 50);
+  window.scrollTo(0, 50);
 });
 
 test('Manual call', function(assert) {
-    window.scrollTo(0, 50);
+  window.scrollTo(0, 50);
 
-    raf(function() {
-        var ev = rafScroll.getCurrent();
-        assert.notDeepEqual(ev.deltaY, 0, 'Calling getCurrent shouldn\'t affect/reset the deltaY value.');
-        rafScroll.destroy();
-        assert.end();
-    });
+  raf(function() {
+    var ev = rafScroll.getCurrent();
+    assert.notDeepEqual(ev.deltaY, 0, 'Calling getCurrent shouldn\'t affect/reset the deltaY value.');
+    rafScroll.destroy();
+    assert.end();
+  });
 });


### PR DESCRIPTION
- Fix `.remove()`
The raf was never stopped even if we didn't have any scroll listeners attached.
tiny-emitter destroys the event type when there is no listeners left https://github.com/scottcorgan/tiny-emitter/blob/master/index.js#L58

- Fix `.destroy()`
First `emitter.off` does nothing in tiny-emitter. We need to specify the event type and the callback we want to remove. https://github.com/scottcorgan/tiny-emitter/blob/master/index.js#L46-L50
Then, we never create a new emitter after setting it to `null`.
Therefore the easiest solution is to create a new emitter and let the GC do its job.

I've added a test for `.destroy()` but the other tests failed already before these changes.